### PR TITLE
Allow installation to external media (SD card)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    android:installLocation="auto"
     xmlns:tools="http://schemas.android.com/tools"
     package="cl.coders.faketraveler">
 


### PR DESCRIPTION
This change will enable installation of the app to external as well as internal flash memory which is important for devices where internal memory is limited but external memory is cheap and abundant in form of micro SD cards.  Thank you for your consideration.