### PR TITLE
fix minSdk because of usage of android:parentActivityName

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId "cl.coders.faketraveler"
-        minSdkVersion 15
+        minSdkVersion 16
         targetSdkVersion 28
         versionCode 6
         versionName "1.6"


### PR DESCRIPTION
`android:parentActivityName` can be used with minimum minSdk `16`